### PR TITLE
[BUGFIX] correct if-then-else structure

### DIFF
--- a/Resources/Private/Templates/Bibliografie/List.html
+++ b/Resources/Private/Templates/Bibliografie/List.html
@@ -25,25 +25,25 @@ Otherwise your changes will be overwritten the next time you save the extension 
                 </f:for>
             </ul>
         </f:then>
+      <f:else>
+          <f:for each="{collections}" as="collection" iteration="collectionIterator">
+              <f:if condition="{collection.data.title}">
+                  <h3 class="tx-slub-zotero-collection-title" id="c{collectionIterator.cycle}">{collection.data.title}</h3>
+              </f:if>
+              <f:if condition="{collection.items}">
+                  <f:then>
+                      <f:for each="{collection.items}" as="item">
+                      <f:render partial="Bibliografie/Item" section="Item" arguments="{item: item}" />
+                      </f:for>
+                  </f:then>
+                  <f:else>
+                      {collection.data.name} : <button data-target="{collection.key}" class="openitems" data-ajaxurl="{f:uri.action(action: 'show', pageType: '6452187564', controller: 'Bibliografie', arguments: {collection:collection.key})}"><f:translate key="LLL:EXT:slub_zotero/Resources/Private/Language/locallang.xlf:show.creations" /></button>
+                      <div id="{collection.key}"></div>
+                  </f:else>
+                  </f:if>
+          </f:for>
+      </f:else>
     </f:if>
-    <f:else>
-        <f:for each="{collections}" as="collection" iteration="collectionIterator">
-            <f:if condition="{collection.data.title}">
-                <h3 class="tx-slub-zotero-collection-title" id="c{collectionIterator.cycle}">{collection.data.title}</h3>
-            </f:if>
-            <f:if condition="{collection.items}">
-                <f:then>
-                    <f:for each="{collection.items}" as="item">
-                    <f:render partial="Bibliografie/Item" section="Item" arguments="{item: item}" />
-                    </f:for>
-                </f:then>
-                <f:else>
-                    {collection.data.name} : <button data-target="{collection.key}" class="openitems" data-ajaxurl="{f:uri.action(action: 'show', pageType: '6452187564', controller: 'Bibliografie', arguments: {collection:collection.key})}"><f:translate key="LLL:EXT:slub_zotero/Resources/Private/Language/locallang.xlf:show.creations" /></button>
-                    <div id="{collection.key}"></div>
-                </f:else>
-                </f:if>
-        </f:for>
-    </f:else>
   </div>
 </f:section>
 </html>

--- a/Resources/Private/Templates/Bibliografie/List.html
+++ b/Resources/Private/Templates/Bibliografie/List.html
@@ -15,33 +15,33 @@ Otherwise your changes will be overwritten the next time you save the extension 
 <f:section name="main">
   <div class="tx-slub-zotero-collections">
     <f:if condition="{settings.zotero.tableOfContents} == 1">
-        <f:then>
-            <h3 class="tx-slub-zotero-collection-toc"><f:translate key="tableOfContents" /></h3>
-            <ul class="toc">
-                <f:for each="{collections}" as="collection" iteration="collectionIterator">
-                    <f:if condition="{collection.data.title}">
-                        <li><f:link.page section="{collectionIterator.cycle}">{collection.data.title}</f:link.page></li>
-                    </f:if>
-                </f:for>
-            </ul>
-        </f:then>
-      <f:else>
+      <f:then>
+        <h3 class="tx-slub-zotero-collection-toc"><f:translate key="tableOfContents" /></h3>
+        <ul class="toc">
           <f:for each="{collections}" as="collection" iteration="collectionIterator">
-              <f:if condition="{collection.data.title}">
-                  <h3 class="tx-slub-zotero-collection-title" id="c{collectionIterator.cycle}">{collection.data.title}</h3>
-              </f:if>
-              <f:if condition="{collection.items}">
-                  <f:then>
-                      <f:for each="{collection.items}" as="item">
-                      <f:render partial="Bibliografie/Item" section="Item" arguments="{item: item}" />
-                      </f:for>
-                  </f:then>
-                  <f:else>
-                      {collection.data.name} : <button data-target="{collection.key}" class="openitems" data-ajaxurl="{f:uri.action(action: 'show', pageType: '6452187564', controller: 'Bibliografie', arguments: {collection:collection.key})}"><f:translate key="LLL:EXT:slub_zotero/Resources/Private/Language/locallang.xlf:show.creations" /></button>
-                      <div id="{collection.key}"></div>
-                  </f:else>
-                  </f:if>
+            <f:if condition="{collection.data.title}">
+              <li><f:link.page section="{collectionIterator.cycle}">{collection.data.title}</f:link.page></li>
+            </f:if>
           </f:for>
+        </ul>
+      </f:then>
+      <f:else>
+        <f:for each="{collections}" as="collection" iteration="collectionIterator">
+          <f:if condition="{collection.data.title}">
+            <h3 class="tx-slub-zotero-collection-title" id="c{collectionIterator.cycle}">{collection.data.title}</h3>
+          </f:if>
+          <f:if condition="{collection.items}">
+            <f:then>
+              <f:for each="{collection.items}" as="item">
+                <f:render partial="Bibliografie/Item" section="Item" arguments="{item: item}" />
+              </f:for>
+            </f:then>
+            <f:else>
+              {collection.data.name} : <button data-target="{collection.key}" class="openitems" data-ajaxurl="{f:uri.action(action: 'show', pageType: '6452187564', controller: 'Bibliografie', arguments: {collection:collection.key})}"><f:translate key="LLL:EXT:slub_zotero/Resources/Private/Language/locallang.xlf:show.creations" /></button>
+              <div id="{collection.key}"></div>
+            </f:else>
+          </f:if>
+        </f:for>
       </f:else>
     </f:if>
   </div>


### PR DESCRIPTION
Without the fix there is no parsing error but we experienced strangely missing content if TYPO3 caches are active and two plugins are on one page.